### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm:
+  - jruby-18mode
+  - jruby-19mode
+  - jruby-head
+script: bundle exec rake test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Ruby wrapper for [google-gson][1] library
 
+[![Build Status](https://travis-ci.org/avsej/gson.rb.png)][2]
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -110,3 +112,4 @@ Additional decoder options:
 5. Create new Pull Request
 
 [1]: https://code.google.com/p/google-gson/
+[2]: https://travis-ci.org/avsej/gson.rb

--- a/gson.gemspec
+++ b/gson.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency 'rake-compiler', '>= 0.7.5'
+  gem.add_development_dependency 'minitest', '>= 4.7.5'
 end


### PR DESCRIPTION
I cloned this repo and noticed the tests were failing on the `master` branch. The best way to be notified about test failures is to setup continuous integration, so I’ve done that with Travis CI.

This patch also adds a badge to the `README` to make the build status more visible.

All that is required after merging this patch is enabling Travis CI for this project.

Everything is done in a separate commits, so feel free to cherry-pick only the changes you want.

Thanks!
