### PR TITLE
Specify license in gemspec

### DIFF
--- a/gson.gemspec
+++ b/gson.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Ruby wrapper for GSON. https://code.google.com/p/google-gson/}
   gem.summary       = %q{Ruby wrapper for GSON}
   gem.homepage      = "https://github.com/avsej/gson.rb"
+  gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
Hi 👋 

The LICENSE specifies that this gem is Apache 2 licensed:

https://github.com/avsej/gson.rb/blob/7e2fc18be18da8fede00fac8bbc91e2d1a9fcd03/LICENSE#L1-L2

Including it in gemspec as well makes it easier for various tools to generate reports of all the dependencies in a project and their respective license.